### PR TITLE
LPS-74006 CSV, XML export of Form doesn't work for fields fed from data providers

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StringFieldRenderer.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StringFieldRenderer.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Bruno Basto
@@ -140,17 +141,29 @@ public class StringFieldRenderer extends BaseFieldRenderer {
 			return StringPool.BLANK;
 		}
 
+		DDMStructure ddmStructure = field.getDDMStructure();
+
+		DDMFormField ddmFormField = ddmStructure.getDDMFormField(
+			field.getName());
+
 		StringBundler sb = new StringBundler(jsonArray.length() * 2);
 
 		for (int i = 0; i < jsonArray.length(); i++) {
-			LocalizedValue label = getFieldOptionLabel(
-				field, jsonArray.getString(i));
+			String optionValue = jsonArray.getString(i);
 
-			if (label == null) {
-				continue;
+			if (isManualDataSourceType(ddmFormField)) {
+				LocalizedValue label = getFieldOptionLabel(field, optionValue);
+
+				if (label == null) {
+					continue;
+				}
+
+				sb.append(label.getString(locale));
+			}
+			else {
+				sb.append(optionValue);
 			}
 
-			sb.append(label.getString(locale));
 			sb.append(StringPool.COMMA_AND_SPACE);
 		}
 
@@ -159,6 +172,17 @@ public class StringFieldRenderer extends BaseFieldRenderer {
 		}
 
 		return sb.toString();
+	}
+
+	protected boolean isManualDataSourceType(DDMFormField ddmFormField) {
+		String dataSourceType = GetterUtil.getString(
+			ddmFormField.getProperty("dataSourceType"), "manual");
+
+		if (Objects.equals(dataSourceType, "manual")) {
+			return true;
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
Hey @natocesarrego 

I'm filing this solution to master, however, I could not find a way to test the functionality with the reproduction steps outlined in LPS-74006 because the Form screen differs from the one in 7.0/DXP considerably.
For example, on master, you will see fields for category Input and Output, which are not present on 7.0/DXP.

Is there a way to still review it?
Thank you!

Best regards,
István
