### PR TITLE
LPS-76501 Unable to upgrade when en_US is not an available language - TemplateNameException during DDM name validation

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -1632,7 +1632,7 @@ public class DDMTemplateLocalServiceImpl
 			byte[] smallImageBytes)
 		throws PortalException {
 
-		validate(nameMap, script);
+		validate(groupId, nameMap, script);
 
 		if (!smallImage || Validator.isNotNull(smallImageURL) ||
 			(smallImageFile == null) || (smallImageBytes == null)) {
@@ -1678,20 +1678,21 @@ public class DDMTemplateLocalServiceImpl
 		}
 	}
 
-	protected void validate(Map<Locale, String> nameMap, String script)
+	protected void validate(
+			long groupId, Map<Locale, String> nameMap, String script)
 		throws PortalException {
 
-		validateName(nameMap);
+		validateName(groupId, nameMap);
 
 		if (Validator.isNull(script)) {
 			throw new TemplateScriptException("Script is null");
 		}
 	}
 
-	protected void validateName(Map<Locale, String> nameMap)
+	protected void validateName(long groupId, Map<Locale, String> nameMap)
 		throws PortalException {
 
-		String name = nameMap.get(LocaleUtil.getSiteDefault());
+		String name = nameMap.get(PortalUtil.getSiteDefaultLocale(groupId));
 
 		if (Validator.isNull(name)) {
 			throw new TemplateNameException("Name is null");


### PR DESCRIPTION
Hey @natocesarrego 

Could you please review this pull request?

This fixes an error with DDM Template name validation when a site's default locale is not available.
The solution is discussed on [LPS-76501](https://issues.liferay.com/browse/LPS-76501) with @achaparro. 

Thank you and best regards,
István